### PR TITLE
Fix Custom CSS sytlesheet syntax `hred` to `href`

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -286,7 +286,7 @@ You can add custom stylesheets:
 status-website:
   links:
     - rel: stylesheet
-      hred: https://example.com/custom-styles.css
+      href: https://example.com/custom-styles.css
 ```
 
 Or, directly add inline CSS:


### PR DESCRIPTION
The current `yaml` example in the documentation uses `hred`, it should likely be `href`.