### PR TITLE
📱 fix home hero buttons and text ui

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -85,3 +85,10 @@ iframe {
   margin-top: 2rem;
   font-style: italic;
 }
+
+@media screen and (max-width: 966px) {
+  .real {
+    margin-bottom: 0.3rem;
+    margin-top: 1.5rem;
+  }
+}

--- a/src/pages/styles.module.css
+++ b/src/pages/styles.module.css
@@ -15,6 +15,12 @@
   .heroBanner {
     padding: 2rem;
   }
+  .getStarted {
+    padding: 0.4em;
+  }
+  .buttons {
+    margin: 2px;
+  }
 }
 
 .buttons {


### PR DESCRIPTION
**Resolves ISSUE** [#363 ](https://github.com/upptime/upptime/issues/363)

**Fixes**: _Responsiveness_- button overflow at `x-axis` & image hiding the text.

**Preview after fixes:**

<img width="485" alt="Screenshot 2021-06-07 at 16 29 47" src="https://user-images.githubusercontent.com/66865329/121007738-cb5ce880-c7af-11eb-9291-f702fd0347d3.png">
<img width="850" alt="Screenshot 2021-06-07 at 16 29 55" src="https://user-images.githubusercontent.com/66865329/121007743-cc8e1580-c7af-11eb-9864-5aedbcaf0271.png">


