### PR TITLE
Add missing night theme to the docs.

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -230,7 +230,7 @@ status-website:
   theme: light
 ```
 
-Available themes are `light`, `dark`, or `ocean`.
+Available themes are `light`, `dark`, `night` or `ocean`.
 
 You can also write your own custom theme by creating a CSS file in the `assets/` directory of your Upptime repository. For example, if you create a file `assets/my-custom-theme.css`, you can use CSS variables to style your theme. To see a list of all available variables, see the [`dark.css` theme](https://github.com/upptime/status-page/blob/HEAD/static/themes/dark.css):
 


### PR DESCRIPTION
Hey, I noticed that the [night theme](https://github.com/upptime/status-page/blob/1de42c622b7dbfff66ac20524d7cd6b9e5ffa478/static/themes/night.css) isn't listed in the [configuration page](https://upptime.js.org/docs/configuration/) in the docs so I added it (: 

By the way, I'm also thinking about adding screenshots of each theme so people can see them and choose a theme, what do you think?

Cheers!