### PR TITLE
Correct wrong branch in CONTRIBUTING and CoC URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This repository contains the documentation and source code for the Upptime websi
 
 ## 🎁 Contributing
 
-This repository is for Upptime's GitHub Action. We love contributions, so please read our [Contributing Guidelines](https://github.com/upptime/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/upptime/.github/blob/master/CODE_OF_CONDUCT.md) and open an issue or make a pull request!
+This repository is for Upptime's GitHub Action. We love contributions, so please read our [Contributing Guidelines](https://github.com/upptime/.github/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/upptime/.github/blob/main/CODE_OF_CONDUCT.md) and open an issue or make a pull request!
 
 ### Issues
 


### PR DESCRIPTION
They point to `master` while the branches have been renamed to `main`
While GitHub does redirect to the default branch should this still be corrected.