### PR TITLE
Give better ISO timestamp example

### DIFF
--- a/docs/scheduled-maintenance.md
+++ b/docs/scheduled-maintenance.md
@@ -12,8 +12,7 @@ expectedDown: google, hacker-news
 -->
 ```
 
-The `start` and `end` keys are mandatory and should contain an ISO datetime with the start and ending time for the scheduled maintenance respectively.  
-Examples of valid ISO times:
+The `start` and `end` keys are mandatory and should contain an ISO datetime with the start and ending time for the scheduled maintenance respectively.
 
 If you expect that an endpoint will go down during this time, you can add it to `expectedDown` and Upptime will not open an issue if it goes down within this time period. Similarly, you can add `expectedDegraded` if you expect degraded performance. Both these keys should have comma-separated list of slugs.
 

--- a/docs/scheduled-maintenance.md
+++ b/docs/scheduled-maintenance.md
@@ -6,8 +6,8 @@ Upptime helps you set up scheduled maintenance times by opening issues manually.
 
 ```html
 <!--
-start: 2021-02-24T13:00:00.22+00:00
-end: 2021-02-24T14:00:00.22+00:00
+start: 2021-02-24T13:00:00+00:00
+end: 2021-02-24T14:00:00+00:00
 expectedDown: google, hacker-news
 -->
 ```

--- a/docs/scheduled-maintenance.md
+++ b/docs/scheduled-maintenance.md
@@ -6,13 +6,14 @@ Upptime helps you set up scheduled maintenance times by opening issues manually.
 
 ```html
 <!--
-start: 2021-02-24T13:00:00.220Z
-end: 2021-02-24T14:00:00.220Z
+start: 2021-02-24T13:00:00.22+00:00
+end: 2021-02-24T14:00:00.22+00:00
 expectedDown: google, hacker-news
 -->
 ```
 
-The `start` and `end` keys are mandatory and should contain an ISO datetime with the start and ending time for the scheduled maintenance respectively.
+The `start` and `end` keys are mandatory and should contain an ISO datetime with the start and ending time for the scheduled maintenance respectively.  
+Examples of valid ISO times:
 
 If you expect that an endpoint will go down during this time, you can add it to `expectedDown` and Upptime will not open an issue if it goes down within this time period. Similarly, you can add `expectedDegraded` if you expect degraded performance. Both these keys should have comma-separated list of slugs.
 


### PR DESCRIPTION
Pretty sure I'm not the only one who got confused with `.220Z`.
There is really no need to use milliseconds. Instead, should the examples include a valid timezone definition (`+00:00` in this case) to show a proper timestamp format with an off-set time.