### PR TITLE
💚 Change GitHub Pages deploy action

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Build static site
         run: npm run build
       - name: Deploy site to GitHub Pages
-        uses: maxheld83/ghpages@v0.3.0
-        env:
-          BUILD_DIR: "build"
-          GH_PAT: ${{ secrets.GH_PAT }}
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./build


### PR DESCRIPTION
Current GitHub Pages deploy action fails. And action repository ([maxheld83/ghpages](https://github.com/maxheld83/ghpages)) looks like not maintained anymore.

I changed [maxheld83/ghpages](https://github.com/maxheld83/ghpages) with [peaceiris/actions-gh-pages](https://github.com/peaceiris/actions-gh-pages).

Failed action: https://github.com/upptime/upptime.js.org/actions/runs/3107099481/jobs/5034796351
Successfull action: https://github.com/sercanuste/upptime.js.org/actions/runs/3111255468/jobs/5043326077