### PR TITLE
Add missing required token permission (Workflows)

### DIFF
--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -51,7 +51,7 @@ To make commits and publish your website, Upptime requires a personal access tok
 6. In the "Expiration" dropdown, select "90 days" or a custom, longer expiry
 7. In the "Resource Owner" section select the user or organization your Upptime repository belongs to
 8. In the "Repository Access" section select "Only select repositories" and select your Upptime repository
-9. In the "Permissions" > "Repository permissions" section enable read-write access to Actions and Contents
+9. In the "Permissions" > "Repository permissions" section enable read-write access to Actions, Contents, and Workflows
 10. Skip the "Organization permissions" section
 11. Click "Generate token" or "Generate token and request access" (if it is in an org you are not an admin of)
 


### PR DESCRIPTION
The CI still passes when updating .upptimerc.yml without the Workflows permission set but it prevents some data from being updated (the README and websites being tracked).

Example without Workflows permission:
![image](https://github.com/upptime/upptime.js.org/assets/52972357/5b22b795-9955-4808-b513-5f5fd638f66f)

