### PR TITLE
fix(docs): require read-write permission of Issues for PAT

### DIFF
--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -41,7 +41,7 @@ If you don't want to have a publicly-available status website, you don't have to
 
 All sensitive information required, such as API keys, are provided as environment variables. These are stored as GitHub repository secrets (see [Creating and storing encrypted secrets](https://docs.github.com/en/free-pro-team@latest/actions/reference/encrypted-secrets)).
 
-To make commits and publish your website, Upptime requires a personal access token (PAT) with the Actions and Contents read-write permissions, stored as a repository secret named `GH_PAT`. You can create a personal access token by following these steps:
+To make commits and publish your website, Upptime requires a personal access token (PAT) with read-write permissions of Actions, Contents, Issues and Workflows, stored as a repository secret named `GH_PAT`. You can create a personal access token by following these steps:
 
 1. Click on your profile picture on the top-right corner and select "Settings"
 2. In the left sidebar, select "Developer settings"
@@ -51,7 +51,7 @@ To make commits and publish your website, Upptime requires a personal access tok
 6. In the "Expiration" dropdown, select "90 days" or a custom, longer expiry
 7. In the "Resource Owner" section select the user or organization your Upptime repository belongs to
 8. In the "Repository Access" section select "Only select repositories" and select your Upptime repository
-9. In the "Permissions" > "Repository permissions" section enable read-write access to Actions, Contents, and Workflows
+9. In the "Permissions" > "Repository permissions" section enable read-write access to Actions, Contents, Issues and Workflows
 10. Skip the "Organization permissions" section
 11. Click "Generate token" or "Generate token and request access" (if it is in an org you are not an admin of)
 


### PR DESCRIPTION
Close https://github.com/upptime/upptime/issues/797

- Add Issues permission requirement in setup steps.
- Update the summary paragraph to make permission requirements consistent.