### PR TITLE
docs: document skip delete issues feature

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -251,6 +251,17 @@ sites:
       - AnandChowdhary
 ```
 
+### Skip delete issues
+Issues are automatically closed once they are resolved, however if they are open for less than 15 minutes they are deleted instead.
+
+You can disable this behaviour by setting the `skipDeleteIssues` key to `true` in your configuration file:
+
+```yaml
+skipDeleteIssues: true
+```
+
+If issues are deleted, they won't show up in the incident history.
+
 ### Status website
 
 #### Theme

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -27,6 +27,8 @@ To add information about an incident, you can add comments to the issue. By defa
 
 You can see an [example issue #67](https://github.com/upptime/upptime/issues/67).
 
+The issue is automatically deleted (instead of closed) if the downtime is less than 15 minutes. This prevents false positives from showing up in your incident history.
+
 ### GitHub Pages-powered status website
 
 Lastly, you get a beautiful, staticly-generated status website. This website will show users your websites' live status, incident history, and response time graphs. The website is always up-to-date as it uses the GitHub API to fetch data in real-time, and is built using Svelte and Sapper. You can customize the logo, copy, and more to make it your own.


### PR DESCRIPTION
This PR adds documentation on how to prevent uptime from deleting issues. 
The deletion of issues by uptime might get you by surprise, as it can be seen at https://github.com/upptime/upptime/issues/917

It turns out, it is a "feature and not a bug" :) 

See some additional context on this feature: https://github.com/upptime/upptime/discussions/492#discussioncomment-8179339


This PR includes:
- [x] Mentions this behavior in the "hot it works" guide
- [x] Adds the setting in the config page