### PR TITLE
Add Documentation for userContentBaseUrl Configuration in Upptime configuration.md

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -445,6 +445,16 @@ status-website:
   apiBaseUrl: https://api.github.com
 ```
 
+#### Custom raw content URL 
+
+By default, Upptime uses https://raw.githubusercontent.com to fetch raw content from GitHub repositories. This document provides instructions on how to set a custom userContentBaseUrl if you are using a proxy or another content delivery URL.
+
+```yaml
+status-website:
+  userContentBaseUrl: https://raw.githubusercontent.com
+```
+
+
 ### Internationalization
 
 Though our status page is in English, you can use any language with Upptime by supplying the required strings. The list of all required strings is available in [`upptime/status-page/i18n.yml`](https://github.com/upptime/status-page/blob/master/i18n.yml), and you can add them under the i18n key in the configuration file:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -447,7 +447,7 @@ status-website:
 
 #### Custom raw content URL 
 
-By default, Upptime uses https://raw.githubusercontent.com to fetch raw content from GitHub repositories. This document provides instructions on how to set a custom userContentBaseUrl if you are using a proxy or another content delivery URL.
+By default, Upptime uses https://raw.githubusercontent.com to fetch raw content from GitHub repositories. If you are using a proxy or another content delivery URL, you can replace the default user content base URL.
 
 ```yaml
 status-website:


### PR DESCRIPTION
Hey there! I noticed it took me a while to figure out how to set the userContentBaseUrl option in the Upptime configuration, so I thought I'd add a quick note in the docs to help others out. By default, it's https://raw.githubusercontent.com, but you can change it if you need to use a custom URL. I've added a brief explanation and example to make it easier to find. Hope this helps!