### PR TITLE
Update get-started.md with information about including all branches

### DIFF
--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -6,7 +6,7 @@ To use Upptime as an uptime monitor and status website generator, you start by c
 
 ## Create a repository from the template
 
-You can click on the following link to generate a repository using the template: [**Create a new repository**](https://github.com/upptime/upptime/generate) from `upptime/upptime`. Alternatively, you can visit the [Upptime repository on GitHub](https://github.com/upptime/upptime) and click on the "Use this template" button on the top-right. 
+You can click on the following link to generate a repository using the template: [**Create a new repository**](https://github.com/upptime/upptime/generate) from `upptime/upptime`, make sure that you include all branches. Alternatively, you can visit the [Upptime repository on GitHub](https://github.com/upptime/upptime) and click on the "Use this template" button on the top-right. 
 
 In both cases, the next steps are:
 


### PR DESCRIPTION
The documentation references the branch `gh-pages` later on, but GitHub does not include all branches by default when creating new repository from template. I've updated the documentation to include that you should check the `Include all branches` checkbox.

Image:
![Screenshot 2025-03-12 at 16 07 15](https://github.com/user-attachments/assets/653e9818-98c7-4503-90a1-b6b6ec2ad91c)
