### PR TITLE
Fix 'endpoints' typo

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -62,7 +62,7 @@ sites:
     method: DELETE
 ```
 
-#### TCP Port Enpoints
+#### TCP Port Endpoints
 
 To make a TCP ping to any port, you can add the check key "tcp-ping":
 


### PR DESCRIPTION
Fix typo in the configuration documentation. 

Enpoints → Endpoints. 