### PR TITLE
:pencil: Clarify GitHub Pages publishing source

### DIFF
--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -28,12 +28,12 @@ To be able to see and run all the workflows that come with the upptime repo your
 
 ### Enable publishing
 
-To get a static status website, you have to enable GitHub Pages on your new repository.  
-Usually, GitHub will enable GitHub Pages as soon as a `gh-pages` branch is detected. If this doesn't happen should you do the following steps.
+To get a static status website, you have to enable GitHub Pages on your new repository.
+Upptime's generated Static Site CI publishes the built website to the `gh-pages` branch, so configure Pages to deploy from that branch. Usually GitHub enables Pages automatically as soon as the `gh-pages` branch is detected. If it doesn't, follow these steps:
 
 1. Go to your repository settings page
 1. Go to the "Pages" sub-section on the left
-1. Under "Source", change "None" to "Deploy from a branch"
+1. Under "Source", select "Deploy from a branch" instead of "GitHub Actions"
 1. In the Branch dropdown, select `gh-pages` and `/(root)`
 1. Click on "Save"
 


### PR DESCRIPTION
## Summary
- Clarifies that Upptime's Static Site CI publishes to the `gh-pages` branch.
- Keeps the GitHub Pages setup instructions on “Deploy from a branch”, not “GitHub Actions”.
- Notes that the source should remain `gh-pages` / root, matching the generated workflow.

## Test plan
- `git diff --check`
- Added-line security scan
- `npx -y -p node@14 -p npm@6 npm ci`
- `npx -y -p node@14 -p npm@6 npm run build`

Context: this supersedes the direction in #54; the current Upptime workflow still deploys with `peaceiris/actions-gh-pages` to the `gh-pages` branch.
