### PR TITLE
:construction_worker: Modernize docs deploy workflow actions

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -6,6 +6,9 @@ on:
   repository_dispatch:
     types: [build]
   workflow_dispatch:
+permissions:
+  contents: write
+
 jobs:
   release:
     name: Build and deploy site
@@ -13,9 +16,9 @@ jobs:
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v6
       - name: Setup Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v6
         with:
           node-version: 14
       - name: Install dependencies
@@ -23,7 +26,7 @@ jobs:
       - name: Build static site
         run: npm run build
       - name: Deploy site to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./build


### PR DESCRIPTION
## Summary
- Updates the docs deploy workflow from `actions/checkout@v1` to `actions/checkout@v6`
- Updates `actions/setup-node@v1` to `actions/setup-node@v6` while keeping the Node 14 build
- Updates `peaceiris/actions-gh-pages@v3` to `@v4`
- Adds explicit `contents: write` permission for the Pages publish step

## Test Plan
- `git diff --check`
- Parsed `.github/workflows/node.yml` as YAML
- `actionlint -stdin-filename .github/workflows/node.yml - < .github/workflows/node.yml`
- `NODE_OPTIONS=--openssl-legacy-provider npm run build`

Notes: I also verified the site still builds locally after clearing generated `status/`, `build/`, and `.docusaurus/`. A full fresh `npm ci` with the current host npm timed out while fetching supplemental metadata for the legacy v1 lockfile, but the source/dependencies are unchanged and the workflow keeps CI on Node 14.