### PR TITLE
:pencil: Document workflow secret allowlists

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -99,22 +99,67 @@ sites:
     ipv6: true
 ```
 
+#### Secret allowlist
+
+Secrets used by uptime checks and notifications can be restricted with the top-level `secrets` setting. The recommended strict configuration lists every GitHub Actions secret that Upptime may use:
+
+```yaml
+secrets:
+  - PRIVATE_API_URL
+  - PRIVATE_API_TOKEN
+  - PRIVATE_TCP_HOST
+  - PRIVATE_TCP_PORT
+
+sites:
+  - name: Private API
+    url: $PRIVATE_API_URL
+    headers:
+      - "Authorization: Bearer $PRIVATE_API_TOKEN"
+    body: '{ "token": "$PRIVATE_API_TOKEN" }'
+  - name: Private TCP service
+    check: "tcp-ping"
+    url: $PRIVATE_TCP_HOST
+    port: $PRIVATE_TCP_PORT
+```
+
+When `secrets` is present, it is the complete allowlist. This includes `secrets: []`, which passes no contextual secrets:
+
+```yaml
+secrets: []
+```
+
+`GH_PAT` does not need to be listed because generated workflows pass it separately.
+
+For compatibility with existing repositories, omitting `secrets` enables automatic mode. Upptime generates explicit references for secret-like `$NAME` values in supported site URLs, headers, bodies, ports, and response-body checks, together with the finite set of secrets used by Upptime's notification and runtime features. It never passes the complete GitHub Actions secrets context. After confirming which secrets your configuration needs, add an explicit list for strict least privilege.
+
+Secret names must contain only uppercase letters, numbers, and underscores, must not start with a number, and must not start with the reserved `GITHUB_` prefix.
+
+If a literal `$NAME` appears in a request, confirm that the repository secret exists and that `NAME` is included in an explicit `secrets` list. An empty `secrets` list intentionally disables secret substitution. `GH_PAT`, `GITHUB_*` values, `$DYNAMIC_RANDOM_NUMBER`, and `$DYNAMIC_ALPHANUMERIC_STRING` are provided separately or generated at runtime and should not be added.
+
 #### Secret URLs
 
 If you don't want to show a URL publicly, you can use repository secrets (see [Creating and storing encrypted secrets](https://docs.github.com/en/free-pro-team@latest/actions/reference/encrypted-secrets)). Instead of the plain text URL, add the name of the secret prefixed with a $ character:
 
 ```yaml
-- name: Secret Site
-  url: $SECRET_SITE
+secrets:
+  - SECRET_SITE
+
+sites:
+  - name: Secret Site
+    url: $SECRET_SITE
 ```
 
-In the above example, a secret named `SECRET_SITE` (without the $) is stored in the repository. You can add as many secrets as you like, and use them in URLs by adding the `$`prefix. For example, if your environment variable is called`API_URL`, the site URL can be `$API_URL`.
+In the above example, a secret named `SECRET_SITE` (without the `$`) is stored in the repository. You can add as many secrets as you like, and use them in URLs by adding the `$` prefix. For example, if your environment variable is called `API_URL`, the site URL can be `$API_URL`.
 
 You can also use these secrets as part of the URL, for example using a secret called `MY_API_KEY`:
 
 ```yaml
-- name: API endpoint
-  url: https://example.com/get-user/3?api_key=$MY_API_KEY
+secrets:
+  - MY_API_KEY
+
+sites:
+  - name: API endpoint
+    url: https://example.com/get-user/3?api_key=$MY_API_KEY
 ```
 
 #### Request headers
@@ -122,11 +167,15 @@ You can also use these secrets as part of the URL, for example using a secret ca
 Similarly, you can set headers in a request like so:
 
 ```yaml
-- name: API endpoint
-  url: https://example.com/get-user/3
-  headers:
-    - "Authorization: Bearer $SECRET_SITE_2"
-    - "Content-Type: application/json"
+secrets:
+  - SECRET_SITE_2
+
+sites:
+  - name: API endpoint
+    url: https://example.com/get-user/3
+    headers:
+      - "Authorization: Bearer $SECRET_SITE_2"
+      - "Content-Type: application/json"
 ```
 
 #### Request body
@@ -134,12 +183,16 @@ Similarly, you can set headers in a request like so:
 If you want to send data alongside the headers, you can use the `body` key:
 
 ```yaml
-- name: API endpoint with data
-  method: POST
-  url: https://example.com/login
-  headers:
-    - "Content-Type: application/json"
-  body: '{ "password": "hello" }'
+secrets:
+  - PRIVATE_API_TOKEN
+
+sites:
+  - name: API endpoint with data
+    method: POST
+    url: https://example.com/login
+    headers:
+      - "Content-Type: application/json"
+    body: '{ "token": "$PRIVATE_API_TOKEN" }'
 ```
 
 You can add any string to the `body` parameter, but make sure that you supply the relevant content-type header too.

--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -71,6 +71,16 @@ After generating your token, copy it (you will not see it again). Then, add it a
 
 For more information on PATs, read article on the GitHub website: [Creating a personal access token](https://docs.github.com/en/free-pro-team@latest/github/authenticating-to-github/creating-a-personal-access-token).
 
+Generated workflows pass `GH_PAT` separately. For other secrets, add an exact allowlist to `.upptimerc.yml` so Upptime receives only the values it needs:
+
+```yaml title=".upptimerc.yml"
+secrets:
+  - PRIVATE_API_URL
+  - PRIVATE_API_TOKEN
+```
+
+Existing repositories without a `secrets` key use automatic compatibility mode, which generates explicit references for supported configuration and Upptime runtime secrets. It does not pass the complete repository secrets context. See [Secret allowlist](/docs/configuration#secret-allowlist) for strict mode, automatic discovery, and troubleshooting.
+
 ### Update configuration
 
 The `.upptimerc.yml` file is used as the central configuration store. In that file, you can specify which endpoints you want to monitor and configure your status website. For more information, visit [Configuration](/docs/configuration).

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -6,6 +6,16 @@ Using notifications, you can alert your team when an endpoint goes down or exper
 
 ![Secrets](https://user-images.githubusercontent.com/22931360/232315630-59689bdd-6c88-4454-9fd8-8eb64844f968.png)
 
+For strict least privilege, list every notification secret used by your provider in the top-level `.upptimerc.yml` `secrets` allowlist. Include enablement flags stored as secrets, not just credentials and webhook URLs. For Slack:
+
+```yaml title=".upptimerc.yml"
+secrets:
+  - NOTIFICATION_SLACK
+  - NOTIFICATION_SLACK_WEBHOOK_URL
+```
+
+When `secrets` is present, the list is authoritative. For another provider, list every environment variable from its table below that you store as a GitHub secret, including an optional strategy variable. Repositories without a `secrets` key use automatic compatibility mode for Upptime's built-in notification settings. See [Secret allowlist](/docs/configuration#secret-allowlist) for details.
+
 
 Every time an endpoint goes down, a notification with the following text is sent:
 
@@ -40,7 +50,6 @@ For each notification type (Slack, email, etc.), you need to first enable it by 
 | Environment variable             | Value             |
 | -------------------------------- | ----------------- |
 | `NOTIFICATION_SLACK`             | Set to `true`     |
-| `NOTIFICATION_SLACK_WEBHOOK`     | Set to `true`     |
 | `NOTIFICATION_SLACK_WEBHOOK_URL` | Slack webhook URL |
 
 To create a Slack webhook URL, see the article [Incoming webhooks for Slack](https://slack.com/intl/en-in/help/articles/115005265063-Incoming-webhooks-for-Slack) on the Slack website.
@@ -59,8 +68,6 @@ To create a Telegram bot key, see the documentation for [Botfather](https://core
 
 | Environment variable               | Value               |
 | ---------------------------------- | ------------------- |
-| `NOTIFICATION_DISCORD`             | Set to `true`       |
-| `NOTIFICATION_DISCORD_WEBHOOK`     | Set to `true`       |
 | `NOTIFICATION_DISCORD_WEBHOOK_URL` | Discord webhook URL |
 
 To create a Discord webhook URL, see the article [Intro to Webhooks](https://support.discord.com/hc/en-us/articles/228383668-Intro-to-Webhooks) on the Discord Support website.


### PR DESCRIPTION
## Summary

Implementation: upptime/uptime-monitor#312

- document automatic compatibility mode and authoritative explicit allowlists
- add strict private URL, header, body, and port examples
- explain the separate `GH_PAT` path and `secrets: []`
- document notification enablement flags in strict mode
- remove obsolete Slack and Discord variables that the runtime no longer reads
- add migration and unresolved `$NAME` troubleshooting guidance

## Why

Generated workflows no longer receive the complete GitHub Actions secrets context. Users need a clear migration path and exact guidance for configuring least-privilege secret access without breaking private checks or notifications.

## Validation

- `NODE_OPTIONS=--openssl-legacy-provider npm run build`
- `git diff --check`
