### PR TITLE
:arrow_up: Update workflow actions to v7

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -16,9 +16,9 @@ jobs:
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: 14
       - name: Install dependencies


### PR DESCRIPTION
## Summary
- update `actions/checkout` from v6 to v7
- update `actions/setup-node` from v6 to v7
- preserve the legacy Node 14 docs build target and existing deployment behavior

## Validation
- Node 14.21.3 / npm 6.14.18: `npm run build`
- workflow YAML parse
- actionlint 1.7.12
- verified both v7 tags use the Node 24 action runtime and preserve the inputs used here
